### PR TITLE
`gef-extras` can fail on older Python due to typing error

### DIFF
--- a/scripts/libc_function_args/tables/generator.py
+++ b/scripts/libc_function_args/tables/generator.py
@@ -19,7 +19,7 @@ def __get_function_name(l: str) -> str:
     return _function_name
 
 
-def __get_function_args(l: str) -> list[str]:
+def __get_function_args(l: str) -> List[str]:
     _function_args = " (".join(l.split(" (")[1:])
     _function_args = ")".join(_function_args.split(")")[:-1])
     _function_args = _function_args.split(",")
@@ -28,7 +28,7 @@ def __get_function_args(l: str) -> list[str]:
 
 
 def generate_json_file(
-    function_dict: dict[str, list[str]], _params: list[str], outfile_name: pathlib.Path
+    function_dict: dict[str, List[str]], _params: List[str], outfile_name: pathlib.Path
 ) -> bool:
     _dict = {}
     for _key, _value in function_dict.items():


### PR DESCRIPTION
`list[str]` isn't valid in older python versions, it should be `List[str]`


## Description/Motivation/Screenshots

This PR just fixes a small issue in `generator.py` where `list[str]` was placed instead of `List[str]`


## How Has This Been Tested ?

N/A

## Checklist

<!-- N.B.: Your patch won't be reviewed unless fulfilling the following base requirements: -->
<!--- Put an `x` in all the boxes that are complete, or that don't apply -->
*  [ x ] My code follows the code style of this project.
*  [ x ] My change includes a change to the documentation, if required.
*  [ x ] If my change adds new code,
   [adequate tests](https://hugsy.github.io/gef/testing) have been added.
*  [ x ] I have read and agree to the
   [CONTRIBUTING](https://github.com/hugsy/gef/blob/main/.github/CONTRIBUTING.md) document.
